### PR TITLE
Improve LiveKit integration

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -11,20 +11,20 @@ class AssistantAgent(Agent):
     def __init__(self, session: AgentSession):
         super().__init__(instructions="")
         self._session = session
-        self.stage = 0
+        self.stage = 1
         self.user_feeling = None
         self.work_routine = None
         self.daily_essentials = None
 
     async def on_enter(self) -> None:
-        handle = self._session.say(
-            PROMPTS["greeting"],
-            allow_interruptions=False,
-            add_to_chat_ctx=False,
-        )
-        await handle
-        self._session.clear_user_turn()
+        # wait for user feelings to be provided before speaking
         self.stage = 1
+
+    def start_with_feeling(self, feeling: str) -> None:
+        self.user_feeling = feeling
+        self.stage = 2
+        inject = PROMPTS["app_details"].format(user_feeling=feeling)
+        self._session.generate_reply(instructions=inject, allow_interruptions=False)
 
     async def _llm_complete(self, system_prompt: str, user_text: str) -> str:
         ctx = ChatContext.empty()
@@ -55,30 +55,7 @@ class AssistantAgent(Agent):
         self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
     ) -> None:
         text = new_message.text_content or ""
-        if self.stage == 1:
-            analysis_prompt = PROMPTS["analyze_user_feeling"]
-            resp = await self._llm_complete(analysis_prompt, text)
-            data = self._parse_json(resp)
-            if data:
-                print("llm response", data)
-                self.user_feeling = data.get("feeling", {}).get("primary")
-                voice_tone = "Set your voice tone to: " + data.get("voice_tone")
-                if voice_tone:
-                    self.update_instructions(instructions=voice_tone)
-            else:
-                self.user_feeling = "neutral"
-            await self._session.current_agent.update_chat_ctx(ChatContext.empty())
-            self._session.clear_user_turn()
-            #stage 1 to greet and anazlyze user feeling is done
-
-            #moving to stage2
-            self.stage = 2
-            #first acknowlegde user's feeling and explain what this app does
-            inject = PROMPTS["app_details"].format(user_feeling=self.user_feeling)
-            #stop agent from replying and generate a new reply instead
-            self._session.generate_reply(instructions=inject, allow_interruptions=False)
-            raise StopResponse() #this stops the previous flow, where user talked about their feeling
-        elif self.stage == 2:
+        if self.stage == 2:
             validation_prompt = PROMPTS["validate_if_continue"] #validate if user replied that they want to continue or not.
             resp = await self._llm_complete(validation_prompt, text)
             await self._session.current_agent.update_chat_ctx(ChatContext.empty())

--- a/client/app/api/token/route.ts
+++ b/client/app/api/token/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { AccessToken } from 'livekit-server-sdk';
 
-export async function GET() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const feelings = searchParams.get('feelings') || '';
   const id = Math.random().toString(36).slice(2, 10)
   const identity = `user-${id}`;
   const apiKey = process.env.LIVEKIT_API_KEY;
@@ -15,6 +17,7 @@ export async function GET() {
 
   const at = new AccessToken(apiKey, apiSecret, { identity });
   at.addGrant({ roomJoin: true, room: roomName });
+  at.metadata = feelings;
   const token = await at.toJwt();
 
   return NextResponse.json({ token, serverUrl });

--- a/client/app/api/token/route.ts
+++ b/client/app/api/token/route.ts
@@ -4,12 +4,12 @@ import { AccessToken } from 'livekit-server-sdk';
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const feelings = searchParams.get('feelings') || '';
+  const roomName = process.env.LIVEKIT_ROOM || 'assistant';
   const id = Math.random().toString(36).slice(2, 10)
   const identity = `user-${id}`;
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
   const serverUrl = process.env.LIVEKIT_URL;
-  const roomName = `room-${id}`;
 
   if (!apiKey || !apiSecret) {
     return NextResponse.json({ error: 'Missing credentials' }, { status: 500 });

--- a/client/app/api/token/route.ts
+++ b/client/app/api/token/route.ts
@@ -4,9 +4,9 @@ import { AccessToken } from 'livekit-server-sdk';
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const feelings = searchParams.get('feelings') || '';
-  const roomName = process.env.LIVEKIT_ROOM || 'assistant';
   const id = Math.random().toString(36).slice(2, 10)
   const identity = `user-${id}`;
+  const roomName = `room-${id}`
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
   const serverUrl = process.env.LIVEKIT_URL;
@@ -17,6 +17,7 @@ export async function GET(req: Request) {
 
   const at = new AccessToken(apiKey, apiSecret, { identity });
   at.addGrant({ roomJoin: true, room: roomName });
+  console.log("setting metadata", feelings)
   at.metadata = feelings;
   const token = await at.toJwt();
 

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import '@livekit/components-styles';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
       <Link
         href={{
           pathname: "/session",
-          query: { feelings: selected.join(" ") },
+          query: { feelings: selected.join(",") },
         }}
         className="mt-4 px-6 py-2 rounded bg-purple-600 text-white"
       >

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -33,7 +33,15 @@ export default function Home() {
           </button>
         ))}
       </div>
-      <Link href="/session" className="mt-4 px-6 py-2 rounded bg-purple-600 text-white">Continue</Link>
+      <Link
+        href={{
+          pathname: "/session",
+          query: { feelings: selected.join(" ") },
+        }}
+        className="mt-4 px-6 py-2 rounded bg-purple-600 text-white"
+      >
+        Continue
+      </Link>
     </div>
   );
 }

--- a/client/app/session/page.tsx
+++ b/client/app/session/page.tsx
@@ -28,8 +28,15 @@ function SessionContent() {
 }
 
 export default function SessionPage() {
+  const [feelings, setFeelings] = useState('');
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      setFeelings(params.get('feelings') || '');
+    }
+  }, []);
   return (
-    <ConnectRoom>
+    <ConnectRoom feelings={feelings}>
       <SessionContent />
     </ConnectRoom>
   );

--- a/client/app/session/page.tsx
+++ b/client/app/session/page.tsx
@@ -9,6 +9,7 @@ function SessionContent() {
   const { agentTranscriptions, state } = useVoiceAssistant();
   const { buttonProps, enabled } = useTrackToggle({ source: Track.Source.Microphone });
   const [text, setText] = useState('');
+  console.log("state: ", state)
 
   useEffect(() => {
     setText(agentTranscriptions.map((t) => t.text).join(' '));

--- a/client/components/ConnectRoom.tsx
+++ b/client/components/ConnectRoom.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { LiveKitRoom } from '@livekit/components-react';
+import { LiveKitRoom, RoomAudioRenderer } from '@livekit/components-react';
 import { ReactNode, useEffect, useState } from 'react';
 
 export default function ConnectRoom({
@@ -38,6 +38,7 @@ export default function ConnectRoom({
       connect
       data-lk-theme="default"
     >
+      <RoomAudioRenderer />
       {children}
     </LiveKitRoom>
   );

--- a/client/components/ConnectRoom.tsx
+++ b/client/components/ConnectRoom.tsx
@@ -12,7 +12,9 @@ export default function ConnectRoom({
   const [token, setToken] = useState<string>();
   const [serverUrl, setServerUrl] = useState<string>();
   useEffect(() => {
-    fetch(`/api/token?feelings=${encodeURIComponent(feelings)}`)
+    if (token) return;
+    const q = feelings ? `?feelings=${encodeURIComponent(feelings)}` : '';
+    fetch(`/api/token${q}`)
       .then((res) => {
         console.log('LiveKitProvider: Response received', res.status);
         return res.json();
@@ -25,7 +27,7 @@ export default function ConnectRoom({
       .catch((err) => {
         console.error('LiveKitProvider: Fetch error', err);
       });
-  }, [feelings]);
+  }, [feelings, token]);
 
   if (!token) {
     return <div className="p-4 text-center">Connecting...</div>;

--- a/client/components/ConnectRoom.tsx
+++ b/client/components/ConnectRoom.tsx
@@ -2,11 +2,17 @@
 import { LiveKitRoom } from '@livekit/components-react';
 import { ReactNode, useEffect, useState } from 'react';
 
-export default function ConnectRoom({ children }: { children: ReactNode }) {
+export default function ConnectRoom({
+  children,
+  feelings,
+}: {
+  children: ReactNode;
+  feelings: string;
+}) {
   const [token, setToken] = useState<string>();
   const [serverUrl, setServerUrl] = useState<string>();
   useEffect(() => {
-    fetch('/api/token')
+    fetch(`/api/token?feelings=${encodeURIComponent(feelings)}`)
       .then((res) => {
         console.log('LiveKitProvider: Response received', res.status);
         return res.json();
@@ -19,7 +25,7 @@ export default function ConnectRoom({ children }: { children: ReactNode }) {
       .catch((err) => {
         console.error('LiveKitProvider: Fetch error', err);
       });
-  }, []);
+  }, [feelings]);
 
   if (!token) {
     return <div className="p-4 text-center">Connecting...</div>;

--- a/client/components/ConnectRoom.tsx
+++ b/client/components/ConnectRoom.tsx
@@ -12,8 +12,9 @@ export default function ConnectRoom({
   const [token, setToken] = useState<string>();
   const [serverUrl, setServerUrl] = useState<string>();
   useEffect(() => {
-    if (token) return;
+    if (token || !feelings) return;
     const q = feelings ? `?feelings=${encodeURIComponent(feelings)}` : '';
+    console.log("feelings in connect room", q)
     fetch(`/api/token${q}`)
       .then((res) => {
         console.log('LiveKitProvider: Response received', res.status);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@livekit/components-core": "^0.12.7",
         "@livekit/components-react": "^2.9.10",
+        "@livekit/components-styles": "^1.1.6",
         "@types/vara": "^1.1.1",
         "framer-motion": "^12.18.1",
         "livekit-client": "^2.13.8",
@@ -847,6 +848,15 @@
         "@livekit/krisp-noise-filter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@livekit/components-styles": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@livekit/components-styles/-/components-styles-1.1.6.tgz",
+      "integrity": "sha512-V6zfuREC2ksW8z6T6WSbEvdLB5ICVikGz1GtLr59UcxHDyAsKDbuDHAyl3bF3xBqPKYmY3GWF3Qk39rnScyOtA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@livekit/mutex": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@livekit/components-core": "^0.12.7",
     "@livekit/components-react": "^2.9.10",
+    "@livekit/components-styles": "^1.1.6",
     "@types/vara": "^1.1.1",
     "framer-motion": "^12.18.1",
     "livekit-client": "^2.13.8",

--- a/main.py
+++ b/main.py
@@ -46,12 +46,12 @@ async def entrypoint(ctx: agents.JobContext):
 
     async def handle_participant(p: rtc.RemoteParticipant):
         feeling = p.metadata or ctx.decode_token().get("metadata", "")
+        print("feeling", feeling)
         if feeling:
             agent.start_with_feeling(feeling)
 
-    ctx.room.on("participant_connected", lambda p: asyncio.create_task(handle_participant(p)))
-
     for p in ctx.room.remote_participants.values():
+        print("participant", p.identity)
         await handle_participant(p)
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -44,7 +44,15 @@ async def entrypoint(ctx: agents.JobContext):
         ),
     )
 
-    await ctx.connect()
+    async def handle_participant(p: rtc.RemoteParticipant):
+        feeling = p.metadata or ctx.decode_token().get("metadata", "")
+        if feeling:
+            agent.start_with_feeling(feeling)
+
+    ctx.room.on("participant_connected", lambda p: asyncio.create_task(handle_participant(p)))
+
+    for p in ctx.room.remote_participants.values():
+        await handle_participant(p)
 
 if __name__ == "__main__":
     agents.cli.run_app(agents.WorkerOptions(entrypoint_fnc=entrypoint))


### PR DESCRIPTION
## Summary
- pass selected feelings via URL into LiveKit token generation
- fetch token with feeling metadata in `ConnectRoom`
- retrieve feelings on session page and connect automatically
- start agent reply when participant connects using provided feeling
- remove initial greeting logic from the agent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859b3de73a4833298b0259b68f1dbb6