### PR TITLE
Refresh theme and add breathing animation

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -77,71 +77,84 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: #f0f9ff;
+  --foreground: #1f2937;
+  --card: #ffffff;
+  --card-foreground: #1f2937;
+  --popover: #ffffff;
+  --popover-foreground: #1f2937;
+  --primary: #22c55e;
+  --primary-foreground: #ffffff;
+  --secondary: #e0f2f1;
+  --secondary-foreground: #134e4a;
+  --muted: #e0f2f1;
+  --muted-foreground: #475569;
+  --accent: #fbbf24;
+  --accent-foreground: #1f2937;
+  --destructive: #f56565;
+  --border: #cbd5e1;
+  --input: #cbd5e1;
+  --ring: #38bdf8;
+  --chart-1: #67e8f9;
+  --chart-2: #93c5fd;
+  --chart-3: #a5b4fc;
+  --chart-4: #f9a8d4;
+  --chart-5: #fcd34d;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #1f2937;
+  --sidebar-primary: #22c55e;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #fbbf24;
+  --sidebar-accent-foreground: #1f2937;
+  --sidebar-border: #cbd5e1;
+  --sidebar-ring: #38bdf8;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #1f2937;
+  --foreground: #f8fafc;
+  --card: #374151;
+  --card-foreground: #f8fafc;
+  --popover: #374151;
+  --popover-foreground: #f8fafc;
+  --primary: #4ade80;
+  --primary-foreground: #1f2937;
+  --secondary: #164e63;
+  --secondary-foreground: #f8fafc;
+  --muted: #164e63;
+  --muted-foreground: #cbd5e1;
+  --accent: #fbbf24;
+  --accent-foreground: #1f2937;
+  --destructive: #f87171;
+  --border: #475569;
+  --input: #475569;
+  --ring: #38bdf8;
+  --chart-1: #67e8f9;
+  --chart-2: #93c5fd;
+  --chart-3: #a5b4fc;
+  --chart-4: #f9a8d4;
+  --chart-5: #fcd34d;
+  --sidebar: #1f2937;
+  --sidebar-foreground: #f8fafc;
+  --sidebar-primary: #4ade80;
+  --sidebar-primary-foreground: #1f2937;
+  --sidebar-accent: #fbbf24;
+  --sidebar-accent-foreground: #1f2937;
+  --sidebar-border: #475569;
+  --sidebar-ring: #38bdf8;
+}
+
+@keyframes breathe-bg {
+  0%, 100% {
+    background-color: var(--background);
+  }
+  50% {
+    background-color: #e8fbfb;
+  }
+}
+
+.breathe-background {
+  animation: breathe-bg 10s ease-in-out infinite;
 }
 
 @layer base {

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -24,10 +24,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-black`}>
-        {children}
-      </body>
-    </html>
+      <html lang="en">
+        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+          {children}
+        </body>
+      </html>
   );
 }

--- a/client/app/session/page.tsx
+++ b/client/app/session/page.tsx
@@ -75,7 +75,7 @@ function SessionContent() {
 
   console.log("stage", stage)
   return (
-    <div className="relative flex flex-col w-full h-full items-center">
+    <div className="relative flex flex-col w-full min-h-screen h-full items-center breathe-background">
       {/* ToDo; Get device volume when media is being played and use that*/}  
       <VolumeWarning volume={1} />
       <AnimatePresence mode="wait">

--- a/client/components/SuggestionList.tsx
+++ b/client/components/SuggestionList.tsx
@@ -49,9 +49,9 @@ interface SuggestionListProps {
 }
 
 export const SuggestionList: React.FC<SuggestionListProps> = ({data}) => (
-  <div className="p-6 bg-black min-h-screen">
-    <h2 className="text-xl font-semibold text-white mb-4">Suggested Changes</h2>
-    <div className="space-y-4 text-gray-200">
+  <div className="p-6 bg-background min-h-screen text-foreground">
+    <h2 className="text-xl font-semibold mb-4">Suggested Changes</h2>
+    <div className="space-y-4">
       {/* Change summary panel */}
       {data && data.changes?.summary?.length ? (
         <div className="bg-yellow-600/20 text-yellow-100 rounded-lg p-4 flex gap-3">


### PR DESCRIPTION
## Summary
- redesign the default color palette to a calm green/blue theme
- remove forced black background from layout
- adopt new palette in `SuggestionList`
- make session page background slowly pulse

## Testing
- `npm run lint` *(fails: several unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_687362b5ae6c8332a0ba49a58571ffac