### PR TITLE
Revamp theme and navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__/
 lib/
+!client/lib/
 lib64/
 
 # Virtual Environment

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -18,3 +18,25 @@
   height: min-content;
   margin-right: 1rem;
 }
+
+:root {
+  --color-bg-start: #e0f2f1;
+  --color-bg-end: #f0f9ff;
+  --color-primary: #0d9488;
+  --color-secondary: #0ea5e9;
+  --color-text: #1e293b;
+}
+
+body {
+  background-image: linear-gradient(to bottom right, var(--color-bg-start), var(--color-bg-end));
+  color: var(--color-text);
+}
+
+@keyframes breath {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 1; }
+}
+
+.breath-bg {
+  animation: breath 8s ease-in-out infinite;
+}

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import '@livekit/components-styles';
+import "@livekit/components-styles";
+import TitleBar from "@/components/TitleBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-black`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <TitleBar />
         {children}
       </body>
     </html>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
     );
   };
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-8 bg-gradient-to-br from-indigo-50 to-emerald-50 p-6">
+    <div className="flex flex-col items-center justify-center min-h-screen gap-8 bg-gradient-to-br from-[var(--color-bg-start)] to-[var(--color-bg-end)] p-6">
       <Hello />
       <TypeAnimation
         sequence={["How are you feeling today?"]}
@@ -27,7 +27,7 @@ export default function Home() {
           <button
             key={o}
             onClick={() => toggle(o)}
-            className={`px-4 py-2 rounded-full transition-colors border backdrop-blur-md ${selected.includes(o) ? 'bg-indigo-500 text-white' : 'bg-white/60 text-gray-800'}`}
+            className={`px-4 py-2 rounded-full transition-colors border backdrop-blur-md ${selected.includes(o) ? 'bg-[var(--color-primary)] text-white' : 'bg-white/60 text-gray-800'}`}
           >
             {o}
           </button>
@@ -38,7 +38,7 @@ export default function Home() {
           pathname: "/session",
           query: { feelings: selected.join(",") },
         }}
-        className="mt-4 px-6 py-2 rounded bg-purple-600 text-white"
+        className="mt-4 px-6 py-2 rounded bg-[var(--color-secondary)] text-white"
       >
         Continue
       </Link>

--- a/client/app/session/page.tsx
+++ b/client/app/session/page.tsx
@@ -162,7 +162,9 @@ export default function SessionPage() {
   }, []);
   return (
     <ConnectRoom feelings={feelings}>
-      <SessionContent />
+      <div className="min-h-screen breath-bg bg-gradient-to-br from-[var(--color-bg-start)] to-[var(--color-bg-end)]">
+        <SessionContent />
+      </div>
     </ConnectRoom>
   );
 }

--- a/client/components/SuggestionList.tsx
+++ b/client/components/SuggestionList.tsx
@@ -49,9 +49,9 @@ interface SuggestionListProps {
 }
 
 export const SuggestionList: React.FC<SuggestionListProps> = ({data}) => (
-  <div className="p-6 bg-black min-h-screen">
-    <h2 className="text-xl font-semibold text-white mb-4">Suggested Changes</h2>
-    <div className="space-y-4 text-gray-200">
+  <div className="p-6 bg-white/80 min-h-screen backdrop-blur-sm">
+    <h2 className="text-xl font-semibold mb-4">Suggested Changes</h2>
+    <div className="space-y-4 text-gray-800">
       {/* Change summary panel */}
       {data && data.changes?.summary?.length ? (
         <div className="bg-yellow-600/20 text-yellow-100 rounded-lg p-4 flex gap-3">

--- a/client/components/TitleBar.tsx
+++ b/client/components/TitleBar.tsx
@@ -1,0 +1,17 @@
+'use client'
+import Link from 'next/link'
+
+export default function TitleBar() {
+  return (
+    <header className="w-full bg-gradient-to-r from-teal-600 to-sky-600 text-white shadow-md">
+      <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
+        <h1 className="font-bold text-lg">Dummy</h1>
+        <nav className="flex gap-4 text-sm">
+          <Link href="/" className="hover:underline">Home</Link>
+          <Link href="/session" className="hover:underline">Session</Link>
+          <Link href="/dummy" className="hover:underline">Demo</Link>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
## Summary
- create `TitleBar` component with navigation links
- implement peaceful color variables and breathing animation in `globals.css`
- use new theme in layout
- standardize colors in home and suggestion pages
- animate session page background
- store utility `cn` helper
- tweak `.gitignore` to allow tracking client `lib`

## Testing
- `npm run lint` *(fails: several unused vars)*
- `npm run build` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687891f67f7483329b85fbfe8725d220