### PR TITLE
Implement email verification flow & refactor API utilities

### DIFF
--- a/client/app/day/page.tsx
+++ b/client/app/day/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useState, useEffect } from "react";
+import { SERVER_URL } from '@/utils/constants';
 import { DailyPlan } from "@/components/DailyPlan"; // adjust relative path as needed
 import { DailyQuickView } from "@/components/DailyQuickView";   // assumes DailyPlanView component exists
 
@@ -57,11 +58,21 @@ export default function DailyPage() {
 
   useEffect(() => {
     async function fetchPlan() {
-      const ures = await fetch('http://localhost:5005/auth/validate', { credentials: 'include' });
+      const ures = await fetch(`${SERVER_URL}/auth/validate`, { credentials: 'include' });
       if (!ures.ok) { window.location.assign('/'); return; }
       const user = await ures.json();
+      if(!user.verified){
+        await fetch(`${SERVER_URL}/auth/resend-code`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: user.email })
+        });
+        localStorage.setItem('verificationEmail', user.email);
+        window.location.assign('/?verify=1');
+        return;
+      }
       const today = new Date().toLocaleDateString();
-      const res = await fetch(`http://localhost:5005/dailyPlans?userid=${user.id}&date=${encodeURIComponent(today)}`);
+      const res = await fetch(`${SERVER_URL}/dailyPlans?userid=${user.id}&date=${encodeURIComponent(today)}`);
       if (res.ok) {
         const p = await res.json();
         setPlan(p);

--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -3,13 +3,17 @@ import { Login } from '@/components/Login';
 import Hello from '../../components/Hello';
 import { TypeAnimation } from 'react-type-animation';
 import { useEffect, useState } from 'react';
+import { SERVER_URL } from '@/utils/constants';
 
 export default function Home() {
   const [showHelperDiv, setShowHelperDiv] = useState(false);
+  const [verify, setVerify] = useState(false);
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if(params.get('verify') === '1') setVerify(true);
     async function fetchUser() {
       try {
-        const res = await fetch('http://localhost:5005/auth/validate', { credentials: 'include' })
+        const res = await fetch(`${SERVER_URL}/auth/validate`, { credentials: 'include' })
         if (res.ok) {
           const u = await res.json()
           window.location.assign('/day')
@@ -48,7 +52,7 @@ export default function Home() {
           />
         </div>
       )}
-      <Login/>
+      <Login initialVerify={verify}/>
     </div>
   );
 }

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -3,6 +3,7 @@ import Hello from "@/components/Hello";
 import { LoadingView } from "@/components/LoadingView";
 import { Login } from "@/components/Login";
 import { useEffect, useState } from "react";
+import { SERVER_URL } from '@/utils/constants';
 import { TypeAnimation } from 'react-type-animation';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -10,10 +11,16 @@ import { motion, AnimatePresence } from 'framer-motion';
 export default function Home(){
   const [showLogin, setShowLogin] = useState(false)
   const [centerMessage, setCenterMessage] = useState("take a deeep breath")
+  const [verify, setVerify] = useState(false)
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if(params.get('verify') === '1') {
+      setVerify(true)
+      setShowLogin(true)
+    }
     async function fetchUser() {
       try {
-        const res = await fetch('http://localhost:5005/auth/validate', { credentials: 'include' })
+        const res = await fetch(`${SERVER_URL}/auth/validate`, { credentials: 'include' })
         if (res.ok) {
           const u = await res.json()
           setTimeout(()=>{
@@ -40,8 +47,9 @@ export default function Home(){
         const visitor = localStorage.getItem("visitor_id");
         if (!visitor) {
           localStorage.setItem("visitor_id", Math.floor(100000 + Math.random() * 900000).toString())
-        } 
+        }
         setShowLogin(true)
+        if(verify) setVerify(true)
         setCenterMessage("take a few deep breaths");
       }
     }
@@ -119,7 +127,7 @@ export default function Home(){
               </svg>
             </motion.div>
             
-            <Login/>
+            <Login initialVerify={verify}/>
           </motion.div>
         )}
       </AnimatePresence>

--- a/client/components/NavBar.tsx
+++ b/client/components/NavBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+import { SERVER_URL } from '@/utils/constants'
 
 export default function NavBar() {
   const [name, setName] = useState<string>('')
@@ -9,7 +10,7 @@ export default function NavBar() {
   useEffect(() => {
     async function fetchUser() {
       try {
-        const res = await fetch('http://localhost:5005/auth/validate', { credentials: 'include' })
+        const res = await fetch(`${SERVER_URL}/auth/validate`, { credentials: 'include' })
         if (res.ok) {
           const u = await res.json()
           setName(u.name)
@@ -22,7 +23,7 @@ export default function NavBar() {
   }, [])
 
   const handleSignOut = async () => {
-    await fetch('http://localhost:5005/auth/logout', { method: 'POST', credentials: 'include' })
+    await fetch(`${SERVER_URL}/auth/logout`, { method: 'POST', credentials: 'include' })
     window.location.assign('/')
   }
 
@@ -32,7 +33,7 @@ export default function NavBar() {
       <button className="lg:hidden" onClick={() => setOpen(!open)}>
         &#9776;
       </button>
-      <ul className={`lg:flex gap-4 ${open ? 'block' : 'hidden'} lg:static lg:bg-transparent absolute right-4 top-full bg-black rounded-md py-2`}>
+      <ul className={`lg:flex gap-4 overflow-hidden transition-all duration-500 ${open ? 'max-h-60' : 'max-h-0'} lg:max-h-full lg:block lg:static lg:bg-transparent absolute right-4 top-full bg-black rounded-md py-2`} style={{display: open ? 'block' : 'none'}}>
         {name && <li className="px-4 py-2 border-b lg:border-none">{name}</li>}
         <li className="px-4 py-2 lg:p-0"><Link href="/about">About</Link></li>
         <li className="px-4 py-2 lg:p-0"><Link href="/privacy">Privacy Policy</Link></li>

--- a/client/utils/constants.ts
+++ b/client/utils/constants.ts
@@ -1,0 +1,1 @@
+export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:5005';

--- a/client/utils/serverApis.tsx
+++ b/client/utils/serverApis.tsx
@@ -1,6 +1,8 @@
+import { SERVER_URL } from './constants';
+
 export const updateStageAtDB = async (stageNum : Number) => {
     try {
-        const response = await fetch('http://localhost:5005/users/stage/update', {
+        const response = await fetch(`${SERVER_URL}/users/stage/update`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -38,6 +38,22 @@ router.post('/login', async (req, res) => {
       if (user.password !== password) {
         return res.status(401).json({ error: 'Wrong password' });
       }
+      if (!user.verified) {
+        const code = Math.floor(100000 + Math.random() * 900000).toString();
+        user.verificationCode = code;
+        await user.save();
+        const msg = {
+          to: email,
+          from: process.env.SMTP_USER,
+          subject: 'Verify your account',
+          text: `Your verification code is ${code}`,
+        };
+        sgMail
+          .send(msg)
+          .then(() => { console.log('Email sent'); })
+          .catch((error) => { console.error(error); });
+        return res.json({ message: 'verification_required' });
+      }
       res.cookie('user', encrypt(String(user._id)), { httpOnly: true });
       return res.json(user);
     }
@@ -149,7 +165,7 @@ router.get('/validate', async (req, res) => {
     const id = decrypt(cookie);
     const user = await User.findById(id);
     if (!user) return res.status(404).json({ error: 'User not found' });
-    res.json({ id: user._id, name: user.name, email: user.email, stage: user.stage });
+    res.json({ id: user._id, name: user.name, email: user.email, stage: user.stage, verified: user.verified });
   } catch (err) {
     res.status(400).json({ error: 'Invalid cookie' });
   }
@@ -170,6 +186,31 @@ router.get('/verify-user/:id', async (req, res) => {
       email: user.email, 
       stage: user.stage 
     });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/resend-code', async (req, res) => {
+  try {
+    const { email } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    if (user.verified) return res.json({ message: 'already_verified' });
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    user.verificationCode = code;
+    await user.save();
+    const msg = {
+      to: email,
+      from: process.env.SMTP_USER,
+      subject: 'Verify your account',
+      text: `Your verification code is ${code}`,
+    };
+    sgMail
+      .send(msg)
+      .then(() => { console.log('Email sent'); })
+      .catch((error) => { console.error(error); });
+    res.json({ message: 'verification_sent' });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/worker/http_utils.py
+++ b/worker/http_utils.py
@@ -1,0 +1,16 @@
+import aiohttp
+import os
+
+SERVER_URL = os.getenv('SERVER_URL', 'http://localhost:5005')
+
+async def api_get(path: str):
+    url = f"{SERVER_URL.rstrip('/')}/{path.lstrip('/')}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            return resp
+
+async def api_post(path: str, data: dict):
+    url = f"{SERVER_URL.rstrip('/')}/{path.lstrip('/')}"
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=data) as resp:
+            return resp

--- a/worker/main.py
+++ b/worker/main.py
@@ -14,8 +14,8 @@ from dotenv import load_dotenv
 from onboarding_prompts import ONBOARDING_PROMPTS
 import json
 import asyncio
-import aiohttp
 import os
+from .http_utils import api_get
 load_dotenv('.env', override=True)
 
 def createSession() -> AgentSession :
@@ -53,22 +53,19 @@ async def verify_user_exists(user_id: str) -> bool:
     Returns:
         bool: True if user exists, False otherwise
     """
-    server_url = os.getenv('SERVER_URL', 'http://localhost:5005')
-    url = f"{server_url}/auth/verify-user/{user_id}"
-    
+    url = f"auth/verify-user/{user_id}"
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url) as response:
-                if response.status == 200:
-                    user_data = await response.json()
-                    print(f"User {user_id} verified successfully: {user_data.get('name', 'Unknown')}")
-                    return True
-                elif response.status == 404:
-                    print(f"User {user_id} not found")
-                    return False
-                else:
-                    print(f"Error verifying user {user_id}: HTTP {response.status}")
-                    return False
+        response = await api_get(url)
+        if response.status == 200:
+            user_data = await response.json()
+            print(f"User {user_id} verified successfully: {user_data.get('name', 'Unknown')}")
+            return True
+        elif response.status == 404:
+            print(f"User {user_id} not found")
+            return False
+        else:
+            print(f"Error verifying user {user_id}: HTTP {response.status}")
+            return False
     except Exception as e:
         print(f"Failed to verify user {user_id}: {str(e)}")
         return False

--- a/worker/onboarding_agent_helper.py
+++ b/worker/onboarding_agent_helper.py
@@ -1,12 +1,10 @@
 import tiktoken
-import aiohttp
-import os
+from .http_utils import api_post
 import re
 import traceback
 from livekit.agents import llm
 from typing import Optional
 
-server_url = os.getenv('SERVER_URL')
 
 
 async def save_to_server(endpoint: str, data: dict) -> bool:
@@ -20,26 +18,16 @@ async def save_to_server(endpoint: str, data: dict) -> bool:
     Returns:
         bool: True if successful, False otherwise
     """
-    if not server_url:
-        print("Error: SERVER_URL environment variable is not set")
-        return False
-        
-    async with aiohttp.ClientSession() as session:
-        try:
-            url = f"{server_url}/{endpoint}"
-            print(f"Attempting to save to: {url}")
-            async with session.post(url, json=data) as response:
-                if response.status != 201:
-                    print(f"Error saving to {endpoint}: {response.status}")
-                    response_text = await response.text()
-                    print(f"Response: {response_text}")
-                    return False
-                else:
-                    print(f"Successfully saved to {endpoint}")
-                    return True
-        except Exception as e:
-            print(f"Failed to save to {endpoint}: {str(e)}")
-            print(f"Exception type: {type(e).__name__}")
-            print(f"Full exception details:")
-            traceback.print_exc()
+    try:
+        response = await api_post(endpoint, data)
+        if response.status != 201:
+            print(f"Error saving to {endpoint}: {response.status}")
+            response_text = await response.text()
+            print(f"Response: {response_text}")
             return False
+        print(f"Successfully saved to {endpoint}")
+        return True
+    except Exception as e:
+        print(f"Failed to save to {endpoint}: {str(e)}")
+        traceback.print_exc()
+        return False


### PR DESCRIPTION
## Summary
- animate NavBar dropdown
- centralise SERVER_URL in client
- redirect unverified logins to verification flow
- resend verification codes via new endpoint
- add simple HTTP utils for worker

## Testing
- `npm test` *(fails: Plan get by user failed)*

------
https://chatgpt.com/codex/tasks/task_e_68886e4fa55c8332a81f47285aceffe5