### PR TITLE
Add side nav collapse and basic data pages

### DIFF
--- a/client/app/ai-suggestions/page.tsx
+++ b/client/app/ai-suggestions/page.tsx
@@ -1,3 +1,78 @@
-export default function AISuggestionsPage() {
-  return <div className="p-4 text-white">AI Suggestions page</div>;
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SERVER_URL } from '@/utils/constants';
+import { Card } from '@/components/ui/card';
+
+interface Suggestion {
+  suggestion: string;
+  reason: string;
+  targets: string;
 }
+
+interface OngoingChanges {
+  HIGH_PRIORITY?: Suggestion[];
+  MEDIUM_PRIORITY?: Suggestion[];
+  LOW_PRIORITY?: Suggestion[];
+}
+
+export default function AISuggestionsPage() {
+  const [data, setData] = useState<OngoingChanges | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      const ures = await fetch(`${SERVER_URL}/auth/validate`, {
+        credentials: 'include',
+      });
+      if (!ures.ok) {
+        window.location.assign('/login');
+        return;
+      }
+      const user = await ures.json();
+      const res = await fetch(
+        `${SERVER_URL}/ongoingChanges?userid=${user.id}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const arr = await res.json();
+        if (Array.isArray(arr) && arr.length > 0) {
+          arr.sort(
+            (a: any, b: any) =>
+              new Date(b.created_at).getTime() -
+              new Date(a.created_at).getTime()
+          );
+          setData(arr[0]);
+        }
+      }
+    }
+    fetchData();
+  }, []);
+
+  if (!data) {
+    return <div className="p-4 text-white">Loading...</div>;
+  }
+
+  const renderSection = (title: string, items?: Suggestion[]) =>
+    items && items.length > 0 ? (
+      <Card className="bg-gray-900/50 p-4">
+        <h2 className="text-lg font-semibold mb-2">{title}</h2>
+        <ul className="space-y-2">
+          {items.map((s, idx) => (
+            <li key={idx}>
+              <p className="font-medium">{s.suggestion}</p>
+              <p className="text-sm text-gray-400">{s.reason}</p>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    ) : null;
+
+  return (
+    <div className="p-4 text-white space-y-4">
+      {renderSection('High Priority', data.HIGH_PRIORITY)}
+      {renderSection('Medium Priority', data.MEDIUM_PRIORITY)}
+      {renderSection('Low Priority', data.LOW_PRIORITY)}
+    </div>
+  );
+}
+

--- a/client/app/aspirations/page.tsx
+++ b/client/app/aspirations/page.tsx
@@ -1,3 +1,71 @@
-export default function AspirationsPage() {
-  return <div className="p-4 text-white">Aspirations page</div>;
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SERVER_URL } from '@/utils/constants';
+import { Card } from '@/components/ui/card';
+
+interface DesiredHabitChanges {
+  goals?: string[];
+  lifestyle_changes?: string[];
+  activities_to_add?: string[];
+  activities_to_remove?: string[];
 }
+
+export default function AspirationsPage() {
+  const [data, setData] = useState<DesiredHabitChanges | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      const ures = await fetch(`${SERVER_URL}/auth/validate`, {
+        credentials: 'include',
+      });
+      if (!ures.ok) {
+        window.location.assign('/login');
+        return;
+      }
+      const user = await ures.json();
+      const res = await fetch(
+        `${SERVER_URL}/desiredHabitChanges?userid=${user.id}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const arr = await res.json();
+        if (Array.isArray(arr) && arr.length > 0) {
+          arr.sort(
+            (a: any, b: any) =>
+              new Date(b.created_at).getTime() -
+              new Date(a.created_at).getTime()
+          );
+          setData(arr[0]);
+        }
+      }
+    }
+    fetchData();
+  }, []);
+
+  if (!data) {
+    return <div className="p-4 text-white">Loading...</div>;
+  }
+
+  const Section = ({ title, items }: { title: string; items?: string[] }) =>
+    items && items.length > 0 ? (
+      <Card className="bg-gray-900/50 p-4">
+        <h2 className="text-xl font-semibold mb-2">{title}</h2>
+        <ul className="list-disc ml-5 space-y-1">
+          {items.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      </Card>
+    ) : null;
+
+  return (
+    <div className="p-4 text-white space-y-4">
+      <Section title="Goals" items={data.goals} />
+      <Section title="Lifestyle Changes" items={data.lifestyle_changes} />
+      <Section title="Activities to Add" items={data.activities_to_add} />
+      <Section title="Activities to Remove" items={data.activities_to_remove} />
+    </div>
+  );
+}
+

--- a/client/app/journal/page.tsx
+++ b/client/app/journal/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SERVER_URL } from '@/utils/constants';
+import { Card } from '@/components/ui/card';
+
+interface JournalEntry {
+  _id: string;
+  date: string;
+  summary: string;
+  appreciation?: string[];
+  improvements?: string[];
+  created_at: string;
+}
+
+type GroupedJournals = Record<string, JournalEntry[]>;
+
+export default function JournalPage() {
+  const [journals, setJournals] = useState<GroupedJournals>({});
+
+  useEffect(() => {
+    async function fetchJournals() {
+      const ures = await fetch(`${SERVER_URL}/auth/validate`, {
+        credentials: 'include',
+      });
+      if (!ures.ok) {
+        window.location.assign('/login');
+        return;
+      }
+
+      const res = await fetch(`${SERVER_URL}/journals/fetchAll`, {
+        credentials: 'include',
+      });
+      if (res.ok) {
+        const data: JournalEntry[] = await res.json();
+        const grouped = data.reduce((acc: GroupedJournals, entry) => {
+          (acc[entry.date] = acc[entry.date] || []).push(entry);
+          return acc;
+        }, {});
+        Object.keys(grouped).forEach((date) => {
+          grouped[date].sort(
+            (a, b) =>
+              new Date(a.created_at).getTime() -
+              new Date(b.created_at).getTime()
+          );
+        });
+        setJournals(grouped);
+      }
+    }
+    fetchJournals();
+  }, []);
+
+  const formatDate = (date: string) =>
+    new Date(date).toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+    });
+
+  const formatTime = (created: string) =>
+    new Date(created).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+  const dates = Object.keys(journals).sort((a, b) => b.localeCompare(a));
+
+  return (
+    <div className="p-4 text-white space-y-8">
+      {dates.map((date) => (
+        <div key={date}>
+          <h2 className="text-lg font-semibold mb-4">{formatDate(date)}</h2>
+          <div className="relative border-l border-gray-700 ml-2">
+            {journals[date].map((entry) => (
+              <div key={entry._id} className="relative pl-6 pb-6">
+                <span className="absolute left-0 top-1 w-3 h-3 rounded-full bg-white" />
+                <div>
+                  <time className="text-sm text-gray-400">
+                    {formatTime(entry.created_at)}
+                  </time>
+                  <Card className="bg-gray-900/50 p-4 mt-2 space-y-2">
+                    <p>{entry.summary}</p>
+                    {entry.appreciation?.length ? (
+                      <div>
+                        <h3 className="font-semibold">Appreciation</h3>
+                        <ul className="list-disc ml-5 space-y-1">
+                          {entry.appreciation.map((a, i) => (
+                            <li key={i}>{a}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                    {entry.improvements?.length ? (
+                      <div>
+                        <h3 className="font-semibold">Improvements</h3>
+                        <ul className="list-disc ml-5 space-y-1">
+                          {entry.improvements.map((a, i) => (
+                            <li key={i}>{a}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                  </Card>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/client/app/weekly-routine/page.tsx
+++ b/client/app/weekly-routine/page.tsx
@@ -1,3 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import WeeklyRoutine, { RoutineData } from '@/components/WeeklyRoutine';
+import { SERVER_URL } from '@/utils/constants';
+
+const daysOfWeek = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
 export default function WeeklyRoutinePage() {
-  return <div className="p-4 text-white">Weekly routine page</div>;
+  const [routine, setRoutine] = useState<RoutineData | null>(null);
+
+  useEffect(() => {
+    async function fetchRoutine() {
+      const ures = await fetch(`${SERVER_URL}/auth/validate`, {
+        credentials: 'include',
+      });
+      if (!ures.ok) {
+        window.location.assign('/login');
+        return;
+      }
+      const user = await ures.json();
+      const res = await fetch(
+        `${SERVER_URL}/weeklyRoutines?userid=${user.id}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const arr = await res.json();
+        if (Array.isArray(arr) && arr.length > 0) {
+          arr.sort(
+            (a: any, b: any) =>
+              new Date(b.created_at).getTime() -
+              new Date(a.created_at).getTime()
+          );
+          const latest = arr[0];
+          const data: RoutineData = {
+            days: daysOfWeek.map((day) => ({
+              day,
+              blocks: (latest[day] || []).map((blk: any) => ({
+                start: blk.start,
+                end: blk.end,
+                label: blk.name,
+                category: blk.category,
+                location: blk.location,
+              })),
+            })),
+          };
+          setRoutine(data);
+        }
+      }
+    }
+    fetchRoutine();
+  }, []);
+
+  if (!routine) {
+    return <div className="p-4 text-white">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 text-white">
+      <WeeklyRoutine data={routine} />
+    </div>
+  );
 }
+

--- a/client/components/SideNav.tsx
+++ b/client/components/SideNav.tsx
@@ -1,16 +1,62 @@
 'use client';
+
 import Link from 'next/link';
+import { useState } from 'react';
+import {
+  Calendar,
+  CalendarClock,
+  Star,
+  Sparkles,
+  Repeat,
+  BookOpen,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: JSX.Element;
+}
 
 export default function SideNav() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const items: NavItem[] = [
+    { href: '/today', label: 'Today', icon: <Calendar className="w-5 h-5" /> },
+    { href: '/tomorrow', label: 'Tomorrow', icon: <CalendarClock className="w-5 h-5" /> },
+    { href: '/aspirations', label: 'Aspirations', icon: <Star className="w-5 h-5" /> },
+    { href: '/ai-suggestions', label: 'AI Suggestions', icon: <Sparkles className="w-5 h-5" /> },
+    { href: '/weekly-routine', label: 'Weekly Routine', icon: <Repeat className="w-5 h-5" /> },
+    { href: '/journal', label: 'Journal', icon: <BookOpen className="w-5 h-5" /> },
+  ];
+
   return (
-    <nav className="w-48 bg-gray-900 text-white min-h-screen p-4">
-      <ul className="space-y-2">
-        <li><Link href="/today">Today</Link></li>
-        <li><Link href="/tomorrow">Tomorrow</Link></li>
-        <li><Link href="/aspirations">Aspirations</Link></li>
-        <li><Link href="/ai-suggestions">AI Suggestions</Link></li>
-        <li><Link href="/weekly-routine">Weekly Routine</Link></li>
+    <nav
+      className={`bg-gray-900 text-white min-h-screen p-4 flex flex-col transition-all duration-300 ${
+        collapsed ? 'w-16' : 'w-48'
+      }`}
+    >
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="mb-6 self-end text-gray-400 hover:text-white"
+      >
+        {collapsed ? <ChevronRight /> : <ChevronLeft />}
+      </button>
+      <ul className="space-y-2 flex-1">
+        {items.map((item) => (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              className="flex items-center gap-2 hover:text-gray-300"
+            >
+              {item.icon}
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          </li>
+        ))}
       </ul>
     </nav>
   );
 }
+

--- a/client/components/WeeklyRoutine.tsx
+++ b/client/components/WeeklyRoutine.tsx
@@ -84,7 +84,7 @@ function formatTime12Hour(timeStr: string): string {
 }
 
 export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps) {
-  const [viewMode, setViewMode] = useState<"desktop" | "mobile">("mobile")
+  const [viewMode, setViewMode] = useState<"desktop" | "mobile">("desktop")
   const [collapsedDays, setCollapsedDays] = useState<Set<string>>(new Set())
 
   const hourSlots = useMemo(() => generateHourSlots(), [])
@@ -206,7 +206,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
       <div className="space-y-4">
         {/* Grid View */}
         <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg overflow-hidden">
-          <div className="overflow-auto max-h-[70vh]">
+          <div className="">
             <div className="min-w-max">
               {/* Header */}
               <div
@@ -219,7 +219,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
                 {data.days.map((day) => (
                   <div
                     key={day.day}
-                    className="bg-gray-50 p-3 text-xs font-medium text-gray-700 text-center border-r border-gray-200 last:border-r-0"
+                    className="bg-gray-500 p-3 text-xs font-medium text-gray-700 text-center border-r border-gray-200 last:border-r-0"
                   >
                     {day.day}
                   </div>
@@ -233,7 +233,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
               >
                 {hourSlots.map((hourSlot, hourIndex) => (
                   <div key={hourSlot} className="contents">
-                    <div className="bg-white p-2 text-xs font-mono text-gray-500 text-center sticky left-0 z-10 border-r border-gray-200 border-b border-gray-200">
+                    <div className="bg-gray-200 p-2 text-xs font-mono text-gray-500 text-center sticky left-0 z-10 border-r border-gray-200 border-b border-gray-200">
                       {formatTime12Hour(hourSlot)}
                     </div>
                     {dayGridData.map((dayData, dayIndex) => {
@@ -277,7 +277,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
         </Card>
 
         {/* Legend */}
-        <Card className="p-3 bg-white/80 backdrop-blur-sm border-0 shadow-lg">
+        {/* <Card className="p-3 bg-white/80 backdrop-blur-sm border-0 shadow-lg">
           <div className="grid grid-cols-2 gap-2 text-xs">
             {Object.entries(categoryColors).map(([category]) => (
               <div key={category} className="flex items-center gap-2">
@@ -286,7 +286,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
               </div>
             ))}
           </div>
-        </Card>
+        </Card> */}
       </div>
     )
   }
@@ -295,7 +295,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
     <div className="space-y-4">
       {/* View Toggle */}
       <div className="flex justify-center">
-        <div className="bg-white/80 backdrop-blur-sm rounded-lg p-1 shadow-lg">
+        <div className="bg-white/80 backdrop-blur-sm rounded-lg p-1 shadow-lg text-black">
           <Button
             variant={viewMode === "desktop" ? "default" : "ghost"}
             size="sm"

--- a/client/components/WeeklyRoutine.tsx
+++ b/client/components/WeeklyRoutine.tsx
@@ -27,23 +27,29 @@ export interface WeeklyRoutinePreviewProps {
 }
 
 const categoryColors = {
-  routine: "bg-slate-100 border-slate-300 text-slate-700",
   work: "bg-blue-100 border-blue-300 text-blue-800",
-  physical: "bg-emerald-100 border-emerald-300 text-emerald-800",
-  mindful: "bg-purple-100 border-purple-300 text-purple-800",
-  sleep: "bg-indigo-100 border-indigo-300 text-indigo-800",
-  goal: "bg-orange-100 border-orange-300 text-orange-800",
-  hobby: "bg-rose-100 border-rose-300 text-rose-800",
+  workout: "bg-red-100 border-red-300 text-red-800",
+  wakeup: "bg-amber-100 border-amber-300 text-amber-800",
+  sleep: "bg-sky-100 border-sky-300 text-sky-800",
+  relax: "bg-indigo-100 border-indigo-300 text-indigo-800",
+  routine: "bg-emerald-100 border-emerald-300 text-emerald-800",
+  goals: "bg-orange-100 border-orange-300 text-orange-800",
+  hobby: "bg-pink-100 border-pink-300 text-pink-800",
+  other: "bg-gray-100 border-gray-300 text-gray-800",
+  meals: "bg-emerald-100 border-emerald-300 text-emerald-800",
 }
 
 const categoryDots = {
-  routine: "bg-slate-400",
   work: "bg-blue-500",
-  physical: "bg-emerald-500",
-  mindful: "bg-purple-500",
-  sleep: "bg-indigo-600",
-  goal: "bg-orange-500",
-  hobby: "bg-rose-500",
+  workout: "bg-red-500",
+  wakeup: "bg-amber-400",
+  sleep: "bg-sky-400",
+  relax: "bg-indigo-400",
+  routine: "bg-emerald-500",
+  goals: "bg-orange-500",
+  hobby: "bg-pink-400",
+  other: "bg-gray-500",
+  meals: "bg-emerald-500",
 }
 
 function parseTime(timeStr: string): { hours: number; minutes: number; nextDay: boolean } {
@@ -98,17 +104,17 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
       {data.days.map((day) => (
         <Card key={day.day} className="bg-white/80 backdrop-blur-sm border-0 shadow-lg overflow-hidden">
           <div
-            className="flex items-center gap-3 p-4 cursor-pointer hover:bg-slate-50/50 transition-colors"
+            className="flex items-center gap-3 p-4 cursor-pointer hover:bg-gray-50/50 transition-colors"
             onClick={() => toggleDayCollapse(day.day)}
           >
             {collapsedDays.has(day.day) ? (
-              <ChevronRight className="w-4 h-4 text-slate-500" />
+              <ChevronRight className="w-4 h-4 text-gray-500" />
             ) : (
-              <ChevronDown className="w-4 h-4 text-slate-500" />
+              <ChevronDown className="w-4 h-4 text-gray-500" />
             )}
-            <h3 className="text-xl font-semibold text-slate-800">{day.day}</h3>
-            <div className="h-px bg-slate-200 flex-1" />
-            <span className="text-sm text-slate-500">{day.blocks.length} activities</span>
+            <h3 className="text-xl font-semibold text-gray-800">{day.day}</h3>
+            <div className="h-px bg-gray-200 flex-1" />
+            <span className="text-sm text-gray-500">{day.blocks.length} activities</span>
           </div>
 
           {!collapsedDays.has(day.day) && (
@@ -204,16 +210,16 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
             <div className="min-w-max">
               {/* Header */}
               <div
-                className="grid bg-slate-200 sticky top-0 z-20"
+                className="grid bg-gray-200 sticky top-0 z-20"
                 style={{ gridTemplateColumns: `120px repeat(${data.days.length}, 140px)` }}
               >
-                <div className="bg-slate-50 p-3 text-xs font-medium text-slate-600 text-center sticky left-0 z-30 border-r border-slate-200">
+                <div className="bg-gray-50 p-3 text-xs font-medium text-gray-600 text-center sticky left-0 z-30 border-r border-gray-200">
                   Time
                 </div>
                 {data.days.map((day) => (
                   <div
                     key={day.day}
-                    className="bg-slate-50 p-3 text-xs font-medium text-slate-700 text-center border-r border-slate-200 last:border-r-0"
+                    className="bg-gray-50 p-3 text-xs font-medium text-gray-700 text-center border-r border-gray-200 last:border-r-0"
                   >
                     {day.day}
                   </div>
@@ -222,12 +228,12 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
 
               {/* Hour slots */}
               <div
-                className="bg-slate-200"
+                className="bg-gray-200"
                 style={{ display: "grid", gridTemplateColumns: `120px repeat(${data.days.length}, 140px)` }}
               >
                 {hourSlots.map((hourSlot, hourIndex) => (
                   <div key={hourSlot} className="contents">
-                    <div className="bg-white p-2 text-xs font-mono text-slate-500 text-center sticky left-0 z-10 border-r border-slate-200 border-b border-slate-200">
+                    <div className="bg-white p-2 text-xs font-mono text-gray-500 text-center sticky left-0 z-10 border-r border-gray-200 border-b border-gray-200">
                       {formatTime12Hour(hourSlot)}
                     </div>
                     {dayGridData.map((dayData, dayIndex) => {
@@ -236,7 +242,7 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
                       return (
                         <div
                           key={`${dayData.day}-${hourSlot}`}
-                          className="relative min-h-[3rem] bg-white border-r border-slate-200 border-b border-slate-200 last:border-r-0"
+                          className="relative min-h-[3rem] bg-white border-r border-gray-200 border-b border-gray-200 last:border-r-0"
                           style={{ minHeight: "3rem" }}
                         >
                           {blocksInHour.map((block, blockIndex) => (
@@ -273,10 +279,10 @@ export default function WeeklyRoutinePreview({ data }: WeeklyRoutinePreviewProps
         {/* Legend */}
         <Card className="p-3 bg-white/80 backdrop-blur-sm border-0 shadow-lg">
           <div className="grid grid-cols-2 gap-2 text-xs">
-            {Object.entries(categoryColors).map(([category, colorClass]) => (
+            {Object.entries(categoryColors).map(([category]) => (
               <div key={category} className="flex items-center gap-2">
                 <div className={`w-3 h-3 rounded-full ${categoryDots[category as keyof typeof categoryDots]}`} />
-                <span className="capitalize text-slate-600">{category}</span>
+                <span className="capitalize text-gray-600">{category}</span>
               </div>
             ))}
           </div>

--- a/server/routes/journals.js
+++ b/server/routes/journals.js
@@ -49,4 +49,17 @@ router.get('/fetchByDate', async (req, res) => {
   }
 });
 
+// Fetch all journals for the authenticated user sorted by date and creation time
+router.get('/fetchAll', async (req, res) => {
+  try {
+    const docs = await Journal.find({ userid: req.user._id }).sort({
+      date: -1,
+      created_at: -1
+    });
+    return res.json(docs);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- make sidebar collapsible and add Journal link
- add Aspirations, AI Suggestions, Weekly Routine, and Journal pages with data fetch
- show all journals grouped by date in a vertical timeline and expose fetchAll endpoint

## Testing
- `npm test` (server) *(fails: Create failed, Plan create failed, Plan get by user failed, Plan delete failed, User delete failed)*
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688ec6cfe8448332ba06e9ec9008df87